### PR TITLE
unbound: tighten permissions of /var/lib/unbound/*

### DIFF
--- a/net/unbound/files/unbound.sh
+++ b/net/unbound/files/unbound.sh
@@ -456,9 +456,10 @@ unbound_mkdir() {
 
 
   # Ensure access and prepare to jail
-  chown -R unbound:unbound $UNBOUND_VARDIR
-  chmod 775 $UNBOUND_VARDIR
-  chmod 664 $UNBOUND_VARDIR/*
+  for file in $(find /var/lib/unbound/ -type f -maxdepth 1); do
+    chown root:unbound $file
+    chmod 640 $file
+  done
 }
 
 ##############################################################################


### PR DESCRIPTION
Maintainer: @EricLuehrsen

Compile tested: not applicable
Run tested: ar71xx, NETGEAR WNDR3700v2, DESIGNATED DRIVER (Bleeding Edge, 50107)

Description:
/usr/lib/unbound/unbound.sh runs as root when doing the whole maintainance so unbound itself does only need to read it's config files

Signed-off-by: Harald Jenny <harald@a-little-linux-box.at>